### PR TITLE
BTRX - 7 - [Windows] After Cancel mtd files are not deleted

### DIFF
--- a/electron_app/DownloadManager.js
+++ b/electron_app/DownloadManager.js
@@ -61,6 +61,7 @@ const destroyDownloads = () => {
       dl.destroy();
     }
   });
+  allDownloads = [];
 };
 
 const setHeader = (access_token) => {

--- a/electron_app/helpers/handleDisk.js
+++ b/electron_app/helpers/handleDisk.js
@@ -18,7 +18,21 @@ const handleFolder = (directory, callback) => {
 };
 
 const fileAlreadyExists = (file) => {
-    return (fs.existsSync(file) || fs.existsSync(file.concat('.mtd')));
+     if (process.platform === 'win32') {
+        let result = false;
+        try{
+            fs.statSync(file.split("\\").join("\\\\").concat('.mtd'));
+        } catch(error) {
+            if(!error.message.includes("no such file or directory")) {
+                result = true;
+            }
+            
+        } finally {
+            return result;
+        }
+    } else {
+        return (fs.existsSync(file) || fs.existsSync(file.concat('.mtd')));
+    }       
 };
 
 const handleDiskSpace = (destination, totalFileSize) => {

--- a/electron_app/helpers/handleDisk.js
+++ b/electron_app/helpers/handleDisk.js
@@ -5,7 +5,8 @@ const diskspace = require('diskspace');
 const electron = require('electron');
 const userDataPath = (electron.app || electron.remote.app).getPath('userData');
 let conditions = { error: false, errorMessage: '' };
-
+const FILE_DOESNT_EXIST = -4058;
+const FILE_ALREADY_EXISTS = -4048;
 const handleFolder = (directory, callback) => {
     if (!fs.existsSync(directory)) {
         mkdirp.sync(directory, (err) => {
@@ -19,20 +20,28 @@ const handleFolder = (directory, callback) => {
 
 const fileAlreadyExists = (file) => {
      if (process.platform === 'win32') {
-        let result = false;
-        try{
-            fs.statSync(file.split("\\").join("\\\\").concat('.mtd'));
-        } catch(error) {
-            if(!error.message.includes("no such file or directory")) {
-                result = true;
-            }
-            
-        } finally {
-            return result;
-        }
+        let filePath = file.split("\\").join("\\\\");
+        return (exists(filePath) || exists(filePath.concat('.mtd')));
+        
+
     } else {
         return (fs.existsSync(file) || fs.existsSync(file.concat('.mtd')));
     }       
+};
+
+const exists = (filePath) => {
+    let result = false;
+    try{
+        fs.statSync(filePath);
+        result = true;
+    } catch(error) {
+        // if(!error.message.includes("no such file or directory")) {
+        if(!error.errno === FILE_DOESNT_EXIST || error.errno === FILE_ALREADY_EXISTS) {
+            result = true;
+        }
+    } finally {
+        return result;
+    }
 };
 
 const handleDiskSpace = (destination, totalFileSize) => {


### PR DESCRIPTION
### Description

_This code will fix the Windows OS bug that causes a collision between .mtd files for downloads with the exact same name and destination folder without preserving the file structure. This will work now the same way Linux/Mac do (adding a version number inside parenthesis)._

_Jira Story : [BTRX-7](https://broadinstitute.atlassian.net/browse/BTRX-7) - [Windows] After Cancel mtd files are not deleted_

----

### Checklist

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [x] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=189431877).
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
